### PR TITLE
returns null if element is from an analytical category

### DIFF
--- a/SpeckleElementsClasses/SpeckleElementsClasses.csproj
+++ b/SpeckleElementsClasses/SpeckleElementsClasses.csproj
@@ -42,9 +42,8 @@
       <HintPath>..\packages\Revit.RevitApiUI.x64.2019.0.0\lib\net45\RevitAPIUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SpeckleCore, Version=1.5.2.343, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\SpeckleCore.1.5.2.343\lib\net45\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SpeckleCore, Version=1.6.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\SpeckleCore.1.6.1\lib\net45\SpeckleCore.dll</HintPath>
     </Reference>
     <Reference Include="SpeckleCoreGeometryClasses, Version=1.2.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SpeckleCoreGeometry.1.2.8\lib\net461\SpeckleCoreGeometryClasses.dll</HintPath>

--- a/SpeckleElementsClasses/packages.config
+++ b/SpeckleElementsClasses/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="Revit.RevitApiUI.x64" version="2019.0.0" targetFramework="net471" />
-  <package id="SpeckleCore" version="1.5.2.343" targetFramework="net471" />
+  <package id="SpeckleCore" version="1.6.1" targetFramework="net471" />
   <package id="SpeckleCoreGeometry" version="1.2.8" targetFramework="net471" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net471" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net471" />

--- a/SpeckleElementsRevit/ConversionsBase.cs
+++ b/SpeckleElementsRevit/ConversionsBase.cs
@@ -54,6 +54,10 @@ namespace SpeckleElementsRevit
 
     public static GenericElement ToSpeckle( this Element myElement )
     {
+
+      if ( myElement.Category.CategoryType == CategoryType.AnalyticalModel )
+        return null;
+
       var generic = new GenericElement();
 
       (generic.Faces, generic.Vertices) = GetFaceVertexArrayFromElement( myElement );

--- a/SpeckleElementsRevit/SpeckleElementsRevit.csproj
+++ b/SpeckleElementsRevit/SpeckleElementsRevit.csproj
@@ -45,9 +45,8 @@
       <HintPath>..\packages\Revit.RevitApiUI.x64.2019.0.0\lib\net45\RevitAPIUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SpeckleCore, Version=1.5.2.343, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\SpeckleCore.1.5.2.343\lib\net45\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SpeckleCore, Version=1.6.1.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\SpeckleCore.1.6.1\lib\net45\SpeckleCore.dll</HintPath>
     </Reference>
     <Reference Include="SpeckleCoreGeometryClasses, Version=1.2.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SpeckleCoreGeometry.1.2.8\lib\net461\SpeckleCoreGeometryClasses.dll</HintPath>

--- a/SpeckleElementsRevit/packages.config
+++ b/SpeckleElementsRevit/packages.config
@@ -3,7 +3,7 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net471" />
   <package id="Revit.RevitApi.x64" version="2019.0.0" targetFramework="net471" />
   <package id="Revit.RevitApiUI.x64" version="2019.0.0" targetFramework="net471" />
-  <package id="SpeckleCore" version="1.5.2.343" targetFramework="net471" />
+  <package id="SpeckleCore" version="1.6.1" targetFramework="net471" />
   <package id="SpeckleCoreGeometry" version="1.2.8" targetFramework="net471" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net471" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net471" />


### PR DESCRIPTION
beforehand, the `GenericElement` conversion routine was gobbling up everything, and returning generic elements. it now returns a null if an `Element` is from `CategoryType.AnalyticalModel`. 